### PR TITLE
Updates for Mirror feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 RUN ./gradlew build
 
 EXPOSE 8088
-CMD xvfb-run -l -a -e /dev/stdout java -jar /artifact/app/build/libs/etoro-api-morten-custom.jar
+CMD xvfb-run -l -a -e /dev/stdout java -jar /artifact/app/build/libs/etoro-api-0.1.3.jar

--- a/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
+++ b/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
@@ -477,12 +477,10 @@ class EtoroHttpClient {
     fun watchMirroredAssets(): Int {
         val mirroredAssets = getMirroredInstrumentIds()
         preloadAssetInfo(mirroredAssets)
-        // Reset watchlist
-        watchlist.watchlist().forEach {
-            watchlist.removeById(it.id)
-        }
         for (id in mirroredAssets) {
-            watchlist.addAssetToWatchlistById(id)
+            if (watchlist.getById(id) == null) {
+                watchlist.addAssetToWatchlistById(id)
+            }
         }
         return mirroredAssets.size
     }

--- a/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
+++ b/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
@@ -91,16 +91,10 @@ class EtoroHttpClient {
 
     var cachedInstruments: ArrayList<EtoroFullAsset> = arrayListOf()
 
-    var cachedLoginData: JSONObject = JSONObject()
-
     var cachedAssetInfoMap: MutableMap<String, JSONObject> = mutableMapOf()
 
-    var cachedMirrorInstrumentIds: ArrayList<String> = arrayListOf()
-
-    var cachedMirrors: List<Mirror> = listOf()
 
     fun getInstruments(): List<EtoroFullAsset> {
-
         val req = HttpRequest.newBuilder()
             .uri(URI("https://api.etorostatic.com/sapi/instrumentsmetadata/V1.1/instruments/bulk?bulkNumber=1&cv=77286b759effc7a624555e466cfb7c86_48a07d20d16ee784216c9eed65623d62&totalBulks=1"))
             .GET()
@@ -183,36 +177,30 @@ class EtoroHttpClient {
     }
 
     fun getLoginData(): JSONObject {
-        if (cachedLoginData.isEmpty) {
-            val request = prepareRequest(
-                "api/logininfo/v1.1/logindata?" +
-                        "client_request_id=${userContext.requestId}&conditionIncludeDisplayableInstruments=false&conditionIncludeMarkets=false&conditionIncludeMetadata=false&conditionIncludeMirrorValidation=false",
-                userContext.exchangeToken, ofString("Real"), metadataService.getMetadata()
-            )
-                .GET()
-                .build()
-            cachedLoginData = JSONObject(client.send(request, HttpResponse.BodyHandlers.ofString()).body())
-        }
-        return cachedLoginData
+        val request = prepareRequest(
+            "api/logininfo/v1.1/logindata?" +
+                    "client_request_id=${userContext.requestId}&conditionIncludeDisplayableInstruments=false&conditionIncludeMarkets=false&conditionIncludeMetadata=false&conditionIncludeMirrorValidation=false",
+            userContext.exchangeToken, ofString("Real"), metadataService.getMetadata()
+        )
+            .GET()
+            .build()
+        return JSONObject(client.send(request, HttpResponse.BodyHandlers.ofString()).body())
     }
 
     fun getMirrors(): List<Mirror> {
-        if (cachedMirrors.isEmpty()) {
-            val mirrors = getLoginData()
-                .getJSONObject("AggregatedResult")
-                .getJSONObject("ApiResponses")
-                .getJSONObject("MirrorsUserData")
-                .getJSONObject("Content")
-                .getJSONArray("users")
-                .toString()
-            val mapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
-            cachedMirrors = mapper.readValue(mirrors)
-        }
-        return cachedMirrors
+        val json = getLoginData()
+            .getJSONObject("AggregatedResult")
+            .getJSONObject("ApiResponses")
+            .getJSONObject("MirrorsUserData")
+            .getJSONObject("Content")
+            .getJSONArray("users")
+            .toString()
+        val mapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
+        return mapper.readValue(json)
     }
 
-    fun getMirrorPositions(mirror_id: String): List<EtoroPosition> {
+    fun getMirrorPositions(mirror_id: String? = null): List<EtoroPosition> {
         val mirrorsData = getLoginData()
             .getJSONObject("AggregatedResult")
             .getJSONObject("ApiResponses")
@@ -220,62 +208,31 @@ class EtoroHttpClient {
             .getJSONObject("Content")
             .getJSONObject("ClientPortfolio")
             .getJSONArray("Mirrors")
-        for (i in 0 until mirrorsData.length()) {
-            val mirror: JSONObject = mirrorsData.getJSONObject(i)
-            val id = mirror.getInt("ParentCID")
-            if (id == mirror_id.toInt()) {
-                val json = mirror.getJSONArray("Positions").toString()
-                var positions: List<EtoroPosition>
+        if (mirror_id != null) {
+            val mirror = mirrorsData.find { it is JSONObject && it.getInt("ParentCID") == mirror_id.toInt() }
+            if (mirror is JSONObject) {
+                val positionsJSON = mirror.getJSONArray("Positions").toString()
                 val mapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                     .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
-                positions = mapper.readValue(json)
-                return positions.map {
-                    val instrumentId = it.InstrumentID
-                    val assetInfo = getCachedAssetInfo(instrumentId)
-                    if (assetInfo == null) {
-                        it
-                    } else {
-                        if (watchlist.getById(instrumentId) != null) {
-                            if (it.IsBuy) {
-                                val price = watchlist.getPrice(
-                                    instrumentId,
-                                    PositionType.SELL,
-                                    assetInfo.getBoolean("AllowDiscountedRates")
-                                )
-                                it.copy(NetProfit = (price - it.OpenRate!!) * it.Leverage * it.Amount / it.OpenRate)
-                            } else {
-                                val price =
-                                    watchlist.getPrice(
-                                        instrumentId,
-                                        PositionType.BUY,
-                                        assetInfo.getBoolean("AllowDiscountedRates")
-                                    )
-                                it.copy(NetProfit = (it.OpenRate!! - price) * it.Leverage * it.Amount / it.OpenRate)
-                            }
-                        } else {
-                            it
-                        }
-                    }
-                }
+                return mapper.readValue(positionsJSON)
             }
+            return listOf()
+        } else {
+            var allPositions: List<EtoroPosition> = listOf()
+            for (i in 0 until mirrorsData.length()) {
+                val mirrorData = mirrorsData.getJSONObject(i)
+                val positionsJSON = mirrorData.getJSONArray("Positions").toString()
+                val mapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
+                val mirrorPositions: List<EtoroPosition> = mapper.readValue(positionsJSON)
+                allPositions = allPositions + mirrorPositions
+            }
+            return allPositions
         }
-        return listOf()
     }
 
-    fun getMirroredInstrumentIds(): ArrayList<String> {
-        if (cachedMirrorInstrumentIds.isEmpty()) {
-            val mirrors = getMirrors()
-            mirrors.forEach {
-                val positions = getMirrorPositions(it.realCID.toString())
-                positions.forEach { it2 ->
-                    if (!cachedMirrorInstrumentIds.contains(it2.InstrumentID)) {
-                        cachedMirrorInstrumentIds.add(it2.InstrumentID)
-                    }
-                }
-            }
-            cachedMirrorInstrumentIds.sort()
-        }
-        return cachedMirrorInstrumentIds
+    fun getMirroredInstrumentIds(): List<String> {
+        return getMirrorPositions().map { it.InstrumentID }.distinct().sorted()
     }
 
     fun getHistoryPositions(
@@ -451,30 +408,8 @@ class EtoroHttpClient {
         }
     }
 
-    fun preloadAssetInfo(ids: ArrayList<String>) {
-        val body = AssetInfoRequest(ids.toTypedArray())
-        val req = prepareRequest(
-            "sapi/trade-real/instruments/private/index?client_request_id=${userContext.requestId}",
-            userContext.exchangeToken, ofString("Real"), metadataService.getMetadata()
-        )
-            .POST(HttpRequest.BodyPublishers.ofString(JSONObject(body).toString()))
-            .build()
-        val instruments =
-            JSONObject(client.send(req, HttpResponse.BodyHandlers.ofString()).body()).getJSONArray("Instruments")
-        for (i in 0 until instruments.length()) {
-            val instrument = instruments.getJSONObject(i)
-            val instrumentId = instrument.getInt("InstrumentID").toString()
-            cachedAssetInfoMap[instrumentId] = instrument
-        }
-    }
-
-    fun getCachedAssetInfo(id: String): JSONObject? {
-        return cachedAssetInfoMap[id]
-    }
-
     fun watchMirroredAssets(): Int {
         val mirroredAssets = getMirroredInstrumentIds()
-        preloadAssetInfo(mirroredAssets)
         for (id in mirroredAssets) {
             if (watchlist.getById(id) == null) {
                 watchlist.addAssetToWatchlistById(id)

--- a/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
+++ b/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
@@ -114,13 +114,11 @@ class EtoroHttpClient {
                 val imageList: ArrayList<Image> = arrayListOf()
                 for (j in 0 until images.length()) {
                     val imageData = images.getJSONObject(j)
-                    try {
-                        val uri = imageData.getString("Uri")
-                        val image = Image(imageData.getInt("Width"), imageData.getInt("Height"), uri)
-                        imageList.add(image)
-                    } catch (e: Exception) {
-                        val b = 0
+                    if (!imageData.has("Uri")) {
+                        continue;
                     }
+                    val image = Image(imageData.getInt("Width"), imageData.getInt("Height"), imageData.getString("Uri"))
+                    imageList.add(image)
                 }
                 var id: String
                 try {

--- a/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
+++ b/src/main/kotlin/ok/work/etoroapi/client/EtoroHttpClient.kt
@@ -195,18 +195,24 @@ class EtoroHttpClient {
             .getJSONObject("Content")
             .getJSONObject("ClientPortfolio")
             .getJSONArray("Mirrors")
-        val userData = loginData.getJSONObject("AggregatedResult")
+        val hasUserData =  loginData.getJSONObject("AggregatedResult")
             .getJSONObject("ApiResponses")
             .getJSONObject("MirrorsUserData")
-            .getJSONObject("Content")
-            .getJSONArray("users")
-        for (i in 0 until mirrors.length()) {
-            val mirror = mirrors.getJSONObject(i)
-            val user = userData.find {
-                it is JSONObject && it.getInt("realCID") == mirror.getInt("ParentCID")
-            }
-            if (user is JSONObject) {
-                mirror.put("User", user)
+            .getInt("StatusCode") == 200
+        if (hasUserData) {
+            var userData = loginData.getJSONObject("AggregatedResult")
+                .getJSONObject("ApiResponses")
+                .getJSONObject("MirrorsUserData")
+                .getJSONObject("Content")
+                .getJSONArray("users")
+            for (i in 0 until mirrors.length()) {
+                val mirror = mirrors.getJSONObject(i)
+                val user = userData.find {
+                    it is JSONObject && it.getInt("realCID") == mirror.getInt("ParentCID")
+                }
+                if (user is JSONObject) {
+                    mirror.put("User", user)
+                }
             }
         }
         val json = mirrors.toString()

--- a/src/main/kotlin/ok/work/etoroapi/controller/MirrorsController.kt
+++ b/src/main/kotlin/ok/work/etoroapi/controller/MirrorsController.kt
@@ -29,11 +29,6 @@ class MirrorsController {
         return httpClient.getMirrorPositions(mirror_id)
     }
 
-    @GetMapping("/instruments")
-    fun getMirrorInstrumentIds(): List<String> {
-        return httpClient.getMirroredInstrumentIds()
-    }
-
     @PutMapping("/watch")
     fun watchMirroredAssets(): Int {
         return httpClient.watchMirroredAssets()

--- a/src/main/kotlin/ok/work/etoroapi/controller/MirrorsController.kt
+++ b/src/main/kotlin/ok/work/etoroapi/controller/MirrorsController.kt
@@ -34,7 +34,7 @@ class MirrorsController {
         return httpClient.getMirroredInstrumentIds()
     }
 
-    @GetMapping("/watch")
+    @PutMapping("/watch")
     fun watchMirroredAssets(): Int {
         return httpClient.watchMirroredAssets()
     }

--- a/src/main/kotlin/ok/work/etoroapi/controller/MirrorsController.kt
+++ b/src/main/kotlin/ok/work/etoroapi/controller/MirrorsController.kt
@@ -25,12 +25,12 @@ class MirrorsController {
     }
 
     @GetMapping("/positions")
-    fun getMirrorPositions(@RequestParam mirror_id: String): List<EtoroPosition> {
+    fun getMirrorPositions(@RequestParam(required = false) mirror_id: String?): List<EtoroPosition> {
         return httpClient.getMirrorPositions(mirror_id)
     }
 
     @GetMapping("/instruments")
-    fun getMirrorInstruments(): ArrayList<String> {
+    fun getMirrorInstrumentIds(): List<String> {
         return httpClient.getMirroredInstrumentIds()
     }
 

--- a/src/main/kotlin/ok/work/etoroapi/model/Mirror.kt
+++ b/src/main/kotlin/ok/work/etoroapi/model/Mirror.kt
@@ -2,4 +2,4 @@ package ok.work.etoroapi.model
 
 data class Avatar(val width: Int, val height: Int, val type: String, val url: String)
 
-data class Mirror(val realCID: Int, val lastName: String, val firstName: String, val aboutMe: String, val avatars: List<Avatar>)
+data class Mirror(val realCID: Int, val username: String, val lastName: String, val firstName: String, val aboutMe: String, val avatars: List<Avatar>)

--- a/src/main/kotlin/ok/work/etoroapi/model/Mirror.kt
+++ b/src/main/kotlin/ok/work/etoroapi/model/Mirror.kt
@@ -1,5 +1,19 @@
 package ok.work.etoroapi.model
 
-data class Avatar(val width: Int, val height: Int, val type: String, val url: String)
+import ok.work.etoroapi.client.EtoroPosition
 
-data class Mirror(val realCID: Int, val username: String, val lastName: String, val firstName: String, val aboutMe: String, val avatars: List<Avatar>)
+data class Mirror(
+    val MirrorID: Int,
+    val InitialInvestment: Double,
+    val DepositSummary: Double,
+    val WithdrawalSummary: Double,
+    val AvailableAmount: Double,
+    val ClosedPositionsNetProfit: Double,
+    val StopLossAmount: Double,
+    val StopLossPercentage: Double,
+    val CopyExistingPositions: Boolean,
+    val IsPaused: Boolean,
+    val PendingForClosure: Boolean,
+    val StartedCopyDate: String,
+    val User: User
+)

--- a/src/main/kotlin/ok/work/etoroapi/model/User.kt
+++ b/src/main/kotlin/ok/work/etoroapi/model/User.kt
@@ -1,7 +1,11 @@
 package ok.work.etoroapi.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Avatar(val width: Int, val height: Int, val type: String, val url: String)
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class User(
     val realCID: Int,
     val username: String,

--- a/src/main/kotlin/ok/work/etoroapi/model/User.kt
+++ b/src/main/kotlin/ok/work/etoroapi/model/User.kt
@@ -1,0 +1,12 @@
+package ok.work.etoroapi.model
+
+data class Avatar(val width: Int, val height: Int, val type: String, val url: String)
+
+data class User(
+    val realCID: Int,
+    val username: String,
+    val lastName: String,
+    val firstName: String,
+    val aboutMe: String,
+    val avatars: List<Avatar>
+)


### PR DESCRIPTION
Hi!

I've merged your changes into the fork now. There were quite a few conflicts, but I think I've resolved them without discarding any of your changes.

This PR contains a variety of changes I've made since you merged:
- Don't cache login-data (it's not static)
- Temporarily stop adding NetProfit to mirrored positions (it has a big impact on performance, and I can live without it for now)
- Refactor the Mirror class. Now it actually contains information about the mirror, and not just the user (which is now in the User class).
- Make mirror_id optional in /mirrors/positions (if not provided, positions from all mirrors are returned)
- Improve /mirrors/watch: Add missing assets to the watchlist in stead of resetting it, and then adding all mirrored assets.
- Removed the /mirrors/instruments route. I used it before I added /mirrors/watch. Now I don't see a need for it.
