### PR TITLE
Replace bundled ChromeDriver in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM markhobson/maven-chrome:jdk-11
-RUN apt update && apt install -y xvfb/stable google-chrome-stable
+RUN apt update && apt install -y xvfb/stable 
 
 WORKDIR /artifact/app
 COPY . .
+RUN cp /usr/bin/chromedriver /artifact/app/drivers/ubuntu/
+
 RUN ./gradlew build
 
 EXPOSE 8088


### PR DESCRIPTION
It looks like the issue was a version mismatch between ChromeDriver (87) and Chrome (88).

This commit replaces the linux chromedriver in `drivers/ubuntu/chromedriver` with version 88 (already installed in the Docker image)

It would probably be a good idea to:
1. Update all the bundled chromedriver binaries to version 88.
2. Check if chromedriver is installed on the host, and only use a bundled binary if necessary.
