### PR TITLE
Add lightstreamer:3.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,9 @@ dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     compile  ("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 
-    compile("com.lightstreamer:ls-javase-client:3.1.1")
+    implementation(files("$projectDir/libs/ls-javase-client-3.1.1.jar"))
+    implementation("com.lightstreamer:ls-log-adapter-java:1.0.2")
+    implementation("com.lightstreamer:ls-javase-client:3.1.1")
 
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.10.2")
 


### PR DESCRIPTION
This should be enough to make it work again while other possibilities are tested.

The dependency with the .jar location is not enough for it to be picked up, we need to tell the .jar location and the dependency as before. This way gradle will put it in your local gradle repository. The repository URL can't be removed as well.